### PR TITLE
Fixed .codeclimate.yml file.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,4 @@
 engines:
-# to turn on an engine, add it here and set enabled to `true`
-# to turn off an engine, set enabled to `false` or remove it
   rubocop:
     enabled: true
   golint:
@@ -10,12 +8,12 @@ engines:
   eslint:
     enabled: true
   csslint:
-    enabled: true
+    enabled: false
 
 exclude_paths:
-- "envs/kickstarter/resources/*"
-- "envs/dev/resources/*"
-- "tests/*"
-- "sql/*"
-- "scripts/*"
-- "docs/*"
+- "envs/kickstarter/resources/**/*"
+- "envs/dev/resources/**/*"
+- "tests/**/*"
+- "sql/**/*"
+- "scripts/**/*"
+- "docs/**/*"


### PR DESCRIPTION
This change addresses a few different issues:

* An ending quote was missing after the last exclusion pattern.
* The exclusion pattern syntax for folders is slightly different than what was originally used (`/**/*` versus `/*`).
* Code Climate's CSSLint Engine is unfortunately bumping into a known issue with this project. This config file disables this Engine for now, as Code Climate's Dev Team addresses this issue.